### PR TITLE
This PR should fail the test.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# This is an example branch. It should fail the test when being PRed into any branch because the nearest MST parent is `Develop`.
+
 # Branch Descendant
 
 This action checks that a branch's nearest MST ancestor is the Master branch. If the nearest MST ancestor is master, then the action will succeed, otherwise it will fail. In either case the action returns the outputs listed below. The commit hashes followed to reach the closest MST parent branch are available in the action's logs, but are not returned as a variable for other actions to use. To see sample output from this action, check the actions tab of this repo. Read more about MST here: https://github.com/colpal/MST-branching.


### PR DESCRIPTION
This PR should fail the test because the closest MST ancestor of the 'compare' branch is Develop.